### PR TITLE
Changed the code of implicit treap

### DIFF
--- a/Data Structures/Implicit Treap.cpp
+++ b/Data Structures/Implicit Treap.cpp
@@ -166,7 +166,7 @@ struct treap {
     lazy_sum_upd(t);
     int idx = add + size(t->l);
     if(t->l) t->l->par = NULL;
-		if(t->r) t->r->par = NULL; 
+    if(t->r) t->r->par = NULL; 
     if(idx <= k)
       split(t->r, t->r, r, k, idx + 1), l = t;
     else

--- a/Data Structures/Implicit Treap.cpp
+++ b/Data Structures/Implicit Treap.cpp
@@ -165,6 +165,8 @@ struct treap {
     lazy_repl_upd(t);
     lazy_sum_upd(t);
     int idx = add + size(t->l);
+    if(t->l) t->l->par = NULL;
+		if(t->r) t->r->par = NULL; 
     if(idx <= k)
       split(t->r, t->r, r, k, idx + 1), l = t;
     else


### PR DESCRIPTION
Added some line which accurately calculates the parent node during split operation.
Let's say I have a treap $t$
i split it into two treap $x$ and $y$
previously either $x$ or $y$ would have parent node after split operation
Now both $x$ and $y$ would have no parent node after split operation.