### PR TITLE
Update Dynamic Convex Hull Trick.cpp

### DIFF
--- a/Dynamic Programming Optimizations/Dynamic Convex Hull Trick.cpp
+++ b/Dynamic Programming Optimizations/Dynamic Convex Hull Trick.cpp
@@ -37,7 +37,7 @@ struct CHT : public multiset<line> {
   }
   void add(ll m, ll b) {
     auto y = insert({ m, b });
-    y->succ = [ = ] { return next(y) == end() ? 0 : &*next(y); };
+    y->succ = [=, this] { return next(y) == end() ? 0 : &*next(y); };
     if (bad(y)) {
       erase(y);
       return;


### PR DESCRIPTION
fix warning: "warning: implicit capture of 'this' via '[=]' is deprecated in C++20 "