### PR TITLE
Force value modulo MOD on constructor

### DIFF
--- a/Number Theory/Combinatorics Basics.cpp
+++ b/Number Theory/Combinatorics Basics.cpp
@@ -6,7 +6,7 @@ template <const int32_t MOD>
 struct modint {
   int32_t value;
   modint() = default;
-  modint(int32_t value_) : value(value_) {}
+  modint(int32_t value_){this->value = value_ % MOD;}
   inline modint<MOD> operator + (modint<MOD> other) const { int32_t c = this->value + other.value; return modint<MOD>(c >= MOD ? c - MOD : c); }
   inline modint<MOD> operator - (modint<MOD> other) const { int32_t c = this->value - other.value; return modint<MOD>(c <    0 ? c + MOD : c); }
   inline modint<MOD> operator * (modint<MOD> other) const { int32_t c = (int64_t)this->value * other.value % MOD; return modint<MOD>(c < 0 ? c + MOD : c); }


### PR DESCRIPTION
Not sure if it can be considered a bug or expected behaviour, but not knowing about it made my code get wrong answer in a problem.

When constructing a `modint` with a value that is greater than or equal to `MOD`, but still fits inside an `int32_t`, this value is saved. If we now add another value greater than `MOD` to it, we can end up with a value greater than or equal to `MOD`, because we would have a value at least `2*MOD`, and the `+=` overload only subtracts at most `MOD`.

To fix it without changing the `modint` code, we should remember to always pass something that is less than `MOD` to the `+=` operation, which I think is error prone. I think it is easier to just force value modulo `MOD` on constructor, which I hope does not break anything else.

Example submissions from the problem I mentioned:
[Original wrong answer, bug at `cur += v[i]`](https://tlx.toki.id/problems/troc-37/D/submissions/2179440)
[Accepted by modding explicitly before addition, i.e. `cur += v[i]%mod`](https://tlx.toki.id/problems/troc-37/D/submissions/2179439)
[Accepted by doing modulo in modint constructor instead of `v[i]%mod`](https://tlx.toki.id/problems/troc-37/D/submissions/2179442)